### PR TITLE
Take into account Dropdowns with 'optgroup'

### DIFF
--- a/src/models/ElementFilter.php
+++ b/src/models/ElementFilter.php
@@ -335,7 +335,9 @@ class ElementFilter extends Model
                     'label' => $single['label'],
                     'level' => 1,
                 ];
-            }, $field->options);
+            }, array_filter($field->options, function($single){
+                return !array_key_exists('optgroup', $single);
+            }));
         }
 
         // lightswitch


### PR DESCRIPTION
When you configure a Dropdown field with 'optgroup', then the $single will not contain a 'value' and 'value' key, instead only 'optgroup' is available.

This removes all 'optgroup' options to ensure the page doesn't break.

Fixes #3 